### PR TITLE
Adjust site-config rule name to not exec again if site-config.iso exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(CONFIG_DIR)/site-config.env: $(CONFIG_DIR) checkenv
 	echo -n "$${PULL_SECRET}" >> $@
 	echo -n "'" >> $@
 
-site-config.iso: $(CONFIG_DIR)/site-config.env
+site-config: $(CONFIG_DIR)/site-config.env
 	mkisofs -o site-config.iso -R -V "ZTC SNO" $<
 
 $(SITE_CONFIG_PATH_IN_LIBVIRT): site-config.iso

--- a/README.md
+++ b/README.md
@@ -9,30 +9,30 @@ Note that single node OpenShift relocation is currently unsupported.
 Install SNO cluster with bootstrap-in-place:
 
 - Set `PULL_SECRET` environment variable to your pull secret:
-```bash
-make start-iso
-```
+    ```bash
+    make start-iso
+    ```
 
-monitor the progress using `make -C bootstrap-in-place-poc/ ssh` and `journalctl -f -u bootkube.service` or `kubectl --kubeconfig ./bootstrap-in-place-poc/sno-workdir/auth/kubeconfig get clusterversion`.
+    monitor the progress using `make -C bootstrap-in-place-poc/ ssh` and `journalctl -f -u bootkube.service` or `kubectl --kubeconfig ./bootstrap-in-place-poc/sno-workdir/auth/kubeconfig get clusterversion`.
 
 - Once the installation is complete create the image template:
-```bash
-make bake
-```
+    ```bash
+    make bake
+    ```
 
 This will apply machine configs to the SNO instance and then shut it down.
 
-- Create the site-config iso wiht the configuration for the SNO instance at edge site:
-```bash
-make site-config.iso CLUSTER_NAME=new-name BASE_DOMAIN=foo.com
-```
-This will create the `site-config.iso` file, which will later get attached to the instance and once the instance is booted the `installation-configuration.service` will scan the attached devices,
-mount the iso, read the configuration and start the reconfiguration process.
+- Create the `site-config.iso` with the configuration for the SNO instance at edge site:
+    ```bash
+    make site-config CLUSTER_NAME=new-name BASE_DOMAIN=foo.com
+    ```
+    This will create the `site-config.iso` file, which will later get attached to the instance and once the instance is booted the `installation-configuration.service` will scan the attached devices,
+    mount the iso, read the configuration and start the reconfiguration process.
 
 - To copy the previous VM's image into `/var/lib/libvirt/images/SNO-baked-image.qcow2` and then create a new SNO instance from it, with the `site-config.iso` attached, run:
 
-```bash
-make start-vm
-```
+    ```bash
+    make start-vm
+    ```
 
 - You can now monitor the progress using `make ssh` and `journalctl -f -u installation-configuration.service`


### PR DESCRIPTION
As a user I run `make site-config.iso CLUSTER_NAME=foo BASE_DOMAIN=foo.bar` and the `site-config.iso` was generated successfully with the intended content. When I run `make start-vm`, the `site-config.iso` was generated again but with the default `CLUSTER_NAME` and `BASE_DOMAIN` values. 

This change renames the `site-config.iso` makefile rule to `site-config`, in order for the latter to not run again and generate a new `site-config.iso` when the user runs `make start-vm`.

