### PR TITLE
Use the correct device label in all cases

### DIFF
--- a/bake/installation-configuration.sh
+++ b/bake/installation-configuration.sh
@@ -29,7 +29,7 @@ do
   sleep 5
 done
 
-DEVICE=$(lsblk -f --json | jq -r '.blockdevices[] | select(.label == "ZTC SNO") | .name')
+DEVICE=$(lsblk -f --json | jq -r '.blockdevices[] | select(.label == "relocation-config") | .name')
 if [[ -n ${DEVICE+x} && ! -f "${RELOCATION_CONFIG_PATH}" ]]; then
   mount_config "${DEVICE}"
   cp -r /mnt/config/* $(dirname ${RELOCATION_CONFIG_PATH})


### PR DESCRIPTION
This was updated in the command to wait for the device to exist, but not where the device is actually used.

This leads to logs like the following:

```
Aug 04 18:07:59 master-0 systemd[1]: Starting Image base SNO configuration script...
Aug 04 18:07:59 master-0 installation-configuration.sh[1363]: Reconfiguring single node OpenShift
Aug 04 18:07:59 master-0 installation-configuration.sh[1363]: Waiting for /opt/openshift/cluster-relocation.yaml
Aug 04 18:07:59 master-0 installation-configuration.sh[1363]: Mounting config iso
Aug 04 18:07:59 master-0 installation-configuration.sh[1456]: mount: /var/mnt/config: /dev is not a block device.
```