### PR TITLE
Use base image from donor booted ostree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ CONFIG_DIR = ./config-dir
 
 ########################
 
+default: help
+
 checkenv:
 ifndef PULL_SECRET
 	$(error PULL_SECRET must be defined)

--- a/ostree-restore.sh
+++ b/ostree-restore.sh
@@ -56,4 +56,4 @@ ostree cat $backup_tag /var.tgz | tar xzC /ostree/deploy/$new_osname --selinux
 log_it Restoring /etc
 ostree cat $backup_tag /etc.tgz | tar xzC /ostree/deploy/$new_osname/deploy/$ostree_deploy --selinux
 
-log_it DONE. You can reboot into the restored system
+log_it "DONE. Be sure to attach the relocation site info to the host (either via ISO or make copy-config) and you can reboot the node"


### PR DESCRIPTION
Creating base system from donor booted ostree will preserve the same kernel and other possible changes commited to the donor OStree