### PR TITLE
General improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bootstrap-in-place-poc
 /bake/installation-configuration.yaml
 /config-dir/
 /credentials/
+/*.kubeconfig

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make vdu
 make bake
 ```
 
-This will apply machine configs to the SNO instance (named sno-test).
+This will apply machine configs to the SNO instance (named sno1).
 
 - (OPTIONAL) With the cluster ready we can create an ostree backup to be imported in an existing SNO
 To do so, the credentials for writing in $BACKUP_REPO must be in an environment variable called `BACKUP_SECRET`, and then run:
@@ -52,7 +52,7 @@ This will backup /var and /etc changes in an OCI container.
 make stop-baked-vm
 ```
 
-This will shutdown the VM and remove it from the hypervisor, leaving us wih the prepaired qcow2 image in /var/lib/libvirt/images/sno-test.qcow2.
+This will shutdown the VM and remove it from the hypervisor, leaving us wih the prepaired qcow2 image in /var/lib/libvirt/images/sno1.qcow2.
 
 - Create the site-config iso wiht the configuration for the SNO instance at edge site:
 ```bash

--- a/external-varlibcontainers-create.sh
+++ b/external-varlibcontainers-create.sh
@@ -2,7 +2,7 @@
 
 KUBECONFIG=${KUBECONFIG:-./bootstrap-in-place-poc/sno-workdir/auth/kubeconfig}
 export KUBECONFIG
-VM_NAME=${VM_NAME:-sno-test}
+VM_NAME=${VM_NAME:-sno1}
 BASE_IMAGE_PATH_SNO=${BASE_IMAGE_PATH_SNO:-/var/lib/libvirt/images/${VM_NAME}.qcow2}
 
 virsh shutdown ${VM_NAME}

--- a/external-varlibcontainers-remove-partition.sh
+++ b/external-varlibcontainers-remove-partition.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VM_NAME=${VM_NAME:-sno-test}
+VM_NAME=${VM_NAME:-sno1}
 BASE_IMAGE_PATH_SNO=${BASE_IMAGE_PATH_SNO:-/var/lib/libvirt/images/${VM_NAME}.qcow2}
 
 qemu-nbd --connect /dev/nbd0 ${BASE_IMAGE_PATH_SNO}


### PR DESCRIPTION
* Ignore `*.kubeconfig` files
* Rename all instances of sno-test with sno1 (following https://github.com/eranco74/bootstrap-in-place-poc/commit/e258f5d2dab3ff5e4229641d266969378c6219e7)
* Rename all instances of our unfortunate original name of `ingrade` with `ibu`
* ostree-restore improvements: more idempotent, will now wait for API