### PR TITLE
Minor fixes and improvements

### DIFF
--- a/bake/installation-configuration.sh
+++ b/bake/installation-configuration.sh
@@ -106,6 +106,11 @@ function wait_for_api {
     echo "Waiting for api ..."
     sleep 5
   done
+  # Wait until the list of nodes has at least one
+  until oc get nodes -ojsonpath='{.items[0].metadata.name}' &> /dev/null; do
+    echo "Waiting for node ..."
+    sleep 5
+  done
   echo "api is available"
 }
 
@@ -204,7 +209,7 @@ fi
 echo "Applying cluster configuration"
 oc apply -f "${RELOCATION_CONFIG_PATH}"
 echo "Waiting for cluster relocation status"
-oc wait --timeout=1h clusterrelocation cluster --for condition=Reconciled=true
+oc wait --timeout=1h clusterrelocation cluster --for condition=Reconciled=true &> /dev/null
 echo "Cluster configuration updated"
 
 if [ -d ${EXTRA_MANIFESTS_PATH} ]; then


### PR DESCRIPTION
- **Fix backup image** name in disk
- **Add parallelism when stopping containers**
- **Add parallelism when precaching container** images
- **Do not use release image anymore** as a source of images to be precached
- **Do not back up the clusterversion resource**, since it was only used to get the list of images from the previous bullet point
- **Do not fail** if **precaching** of some **catalog image** fails (they rotate)
- **Makefile is less verbose when running**
- **Add more thorough check for API server** in installation-configuration.sh

