### PR TITLE
Skip archiving deleted files and delete them during restore 

### DIFF
--- a/ostree-backup.sh
+++ b/ostree-backup.sh
@@ -63,7 +63,8 @@ else
 fi
 
 if [[ ! -f /var/tmp/backup/etc.tgz ]]; then
-    ostree admin config-diff | awk '{print "/etc/" $2}' | xargs tar czf /var/tmp/backup/etc.tgz --selinux
+    ostree admin config-diff | awk '/^D/ {print "/etc/" $2}' > /var/tmp/backup/etc.deletions
+    ostree admin config-diff | awk '!/^D/ {print "/etc/" $2}' | xargs tar czf /var/tmp/backup/etc.tgz --selinux
 else
     echo "Skipping etc backup as it already exists"
 fi

--- a/ostree-restore.sh
+++ b/ostree-restore.sh
@@ -93,6 +93,9 @@ ostree cat $backup_tag /var.tgz | tar xzC /ostree/deploy/$new_osname --selinux
 log_it "Restoring /etc"
 ostree cat $backup_tag /etc.tgz | tar xzC /ostree/deploy/$new_osname/deploy/$ostree_deploy --selinux
 
+log_it "Removing /etc deletions"
+ostree cat $backup_tag /etc.deletions | xargs --no-run-if-empty -ifile rm -f /ostree/deploy/$new_osname/deploy/$ostree_deploy/file
+
 log_it "Waiting for API"
 until oc get clusterversion 2>/dev/null >/dev/null; do
     sleep 5


### PR DESCRIPTION
Currently `ostree admin config-diff` captures deleted files which makes the tar command fail as the file doesn't exist. Updating it so that deleted files are skipped.

Example for this scenario is when chrony service is disabled in favor of ptp:

```
[root@sno core]# ostree admin config-diff | grep chrony
M    chrony.conf
D    systemd/system/multi-user.target.wants/chronyd.service
A    machine-config-daemon/orig/etc/chrony.conf.mcdorig
```
