### PR TITLE
Fix backup of /etc cmd when changed file is a deletion

### DIFF
--- a/ostree-backup.sh
+++ b/ostree-backup.sh
@@ -63,7 +63,7 @@ else
 fi
 
 if [[ ! -f /var/tmp/backup/etc.tgz ]]; then
-    ostree admin config-diff | awk '{print "/etc/" $2}' | xargs tar czf /var/tmp/backup/etc.tgz --selinux
+    ostree admin config-diff | awk '$1 != "D" {print "/etc/" $2}' | xargs tar czf /var/tmp/backup/etc.tgz --selinux
 else
     echo "Skipping etc backup as it already exists"
 fi


### PR DESCRIPTION
When `ostree admin config-diff` detects a deleted file, the pipe with the tar file will try to back up that file provoking the command to fail. 

> **Note:** This usually happens in Telco deployments when PTP is configured and hence, chronyd is disabled and its service unit removed.