### PR TITLE
Get etcd image ref from static pod manifest

### DIFF
--- a/bake/installation-configuration.sh
+++ b/bake/installation-configuration.sh
@@ -50,8 +50,6 @@ set +o allexport
 
 if [[ -d "${NETWORK_CONFIG_PATH}" ]]; then
   echo "Static network configuration exist"
-  # Remove existing networking files
-  rm -f /etc/NetworkManager/system-connections/*
   cp "${NETWORK_CONFIG_PATH}"/*.nmconnection /etc/NetworkManager/system-connections/ -f
   systemctl restart NetworkManager
   # TODO: we might need to delete the connection first


### PR DESCRIPTION
Additional changes:
- Remove existing NIC config files before copying A-side files, to allow for NIC differences
- Always precache images. Expectation is that the system will be sharing container storage across both stateroots. That may be done via /sysroot/containers mechanism or via a separate partition.