### PR TITLE
precache crictl must exit success

### DIFF
--- a/ostree-restore.sh
+++ b/ostree-restore.sh
@@ -94,11 +94,11 @@ oc extract -n openshift-ingress-operator secret/router-ca --keys=tls.key --to=- 
 # If we have a shared container directory, precache all running images + images from ocp release
 if [[ -d "$shared_containers_dir" ]]; then
     log_it "Precaching non-catalog images"
-    grep -vE $(build_catalog_regex) ${img_mnt}/containers.list | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl pull
+    grep -vE $(build_catalog_regex) ${img_mnt}/containers.list | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl pull || true
 
     log_it "Precaching catalog images"
     if grep -q . ${img_mnt}/catalogimages.list; then
-       cat ${img_mnt}/catalogimages.list | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl pull
+       cat ${img_mnt}/catalogimages.list | xargs --no-run-if-empty --max-args 1 --max-procs 10 crictl pull || true
     fi
 fi
 


### PR DESCRIPTION
The precache must exit OK if we do not deal with images that cannot be pulled or retried. Otherwise, the ostree-restore.sh script will exit and won't continue.

In my case, the list of images from the seed contained an image that was removed or updated.

```
FATA[0000] Invalid destination name container-storage:quay.io/lochoa/ibu-imager@sha256:fad7235bcc76310f6a00555da53f41aa896e1a4a5d3196f79f337d9f671af8bf: Invalid image name "container-storage:quay.io/lochoa/ibu-imager@sha256:fad7235bcc76310f6a00555da53f41aa896e1a4a5d3196f79f337d9f671af8bf", unknown transport "container-storage" 
[root@snonode tmp]# skopeo copy docker://quay.io/lochoa/ibu-imager@sha256:fad7235bcc76310f6a00555da53f41aa896e1a4a5d3196f79f337d9f671af8bf container-storage:ibu-imager@sha256:fad7235bcc76310f6a00555da53f41aa896e1a4a5d3196f79f337d9f671af8bf
```

