### PR TITLE
Use ibu-imager to create the seed image

### DIFF
--- a/ostree-backup.sh
+++ b/ostree-backup.sh
@@ -79,7 +79,6 @@ if [[ ! -f /tmp/recert_expired_certs.done ]]; then
         --privileged \
         --rm \
         --replace \
-        -v /var/opt/openshift:/var/opt/openshift \
         -v /etc/kubernetes:/kubernetes \
         -v /var/lib/kubelet:/kubelet \
         -v /etc/machine-config-daemon:/machine-config-daemon \


### PR DESCRIPTION
Use ibu-imager as the default method to create the seed image

Retain older methods for dev and testing purposes, but mark them as deprecated both in the README and in the Makefile help